### PR TITLE
Removes hard-coded http:// and port 2999 for custom Mapbox URLs (Atlas)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -65,7 +65,7 @@ inquirer
         "{url}",
         answers.url.includes("api.mapbox.com") ?
         `https://api.mapbox.com` :
-        `http://${answers.url}:2999`
+        `${answers.url}`
       )
       .replace("{accessToken}", answers.token);
     fs.writeFileSync("src/index.js", indexJS);


### PR DESCRIPTION
### Fix

This PR fixes a bug that prevents Mapbox Atlas users running a production Atlas setup on HTTPS or any port other than 2999 (including standard ports 80/443) from using Quick Launch out of the box.

### How to reproduce the bug
Run `npm run config` with the following options:

```
alexandraulsh@C02X43KGJHD2 quickLaunch (master) $ npm run config

> rapid-deployment-maps@1.0.0 config /Users/alexandraulsh/quickLaunch
> node src/config.js

? What is your Dashboard name? Test
? Describe your dashboard use-case Test
? Favicon location
? Input your logo image source
? Please input the URL of your server http://localhost:2999/
? Input your token pk.eyJ1IjoiYXRsYXMtdXNlciIsImEiOiJjazV6amEzN2owMDAwMDdydDdkdXJramsyIn0.Gd51Sy8ePQJB8N5GQTVeXw
? Input your MongoDB URL localhost
? Input your MongoDB database name annotations
Starting Mongo in Docker
```

After running `npm start`, Quick Launch started but failed to load any maps from Atlas running on my computer on `http://localhost:2999`.

![image](https://user-images.githubusercontent.com/10409657/79677232-fb68b700-81bc-11ea-8c80-312c2a06822b.png)

It turns out that Quick Launch hard-codes the `http://` protocol and port 2999 for any custom server URL. I saw `mapboxgl.baseApiUrl = "http://http://localhost:2999/:2999”;` on line 290 of `index.js`. Using `https://my-atlas-server.com/` resulted in `mapboxgl.baseApiUrl = "http://https://my-atlas-server.com/:2999”;`. Only the string `localhost` worked. This also means you have to run Atlas on `http://localhost:2999`, which is not recommended for production deployments.

With the change in this PR I now have Quick Launch working nicely with Atlas on my laptop:

![image](https://user-images.githubusercontent.com/10409657/79677236-04598880-81bd-11ea-892b-147fab5ac45a.png)

/cc @cmtoomey 
